### PR TITLE
fix: official erpnext blue color

### DIFF
--- a/guidelines/colors.md
+++ b/guidelines/colors.md
@@ -1,4 +1,4 @@
 ##frappe colors
 
 * frappe purple	4b4c9d
-* frappe blue:  5e64ff
+* frappe blue   5e64ff

--- a/guidelines/colors.md
+++ b/guidelines/colors.md
@@ -1,4 +1,4 @@
 ##frappe colors
 
 * frappe purple	4b4c9d
-* frappe blue	7574ff
+* frappe blue:  5e64ff


### PR DESCRIPTION
Indicate that the official blue color is now #5e64ff, per discussions on Telegram, where Rushabh confirmed our research.